### PR TITLE
fix: set a hard limit for max fd

### DIFF
--- a/squid/conf/squid.conf
+++ b/squid/conf/squid.conf
@@ -1,4 +1,5 @@
 coredump_dir /tmp/
+max_filedescriptors 8192
 
 http_port 3128 tcpkeepalive=60,30,3 ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=20MB tls-cert=/squid/etc/bump.crt tls-key=/squid/etc//bump.key cipher=HIGH:MEDIUM:!LOW:!RC4:!SEED:!IDEA:!3DES:!MD5:!EXP:!PSK:!DSS options=NO_TLSv1,NO_SSLv3,SINGLE_DH_USE,SINGLE_ECDH_USE tls-dh=prime256v1:/squid/etc/bump_dhparam.pem
 #https_port 3129 tcpkeepalive=60,30,3 ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=20MB tls-cert=/home/diego_pereira/githome/lens/conf/squid/bump.crt tls-key=/home/diego_pereira/githome/lens/conf/squid/bump.key cipher=HIGH:MEDIUM:!LOW:!RC4:!SEED:!IDEA:!3DES:!MD5:!EXP:!PSK:!DSS options=NO_TLSv1,NO_SSLv3,SINGLE_DH_USE,SINGLE_ECDH_USE tls-dh=prime256v1:/home/diego_pereira/githome/lens/conf/squid/bump_dhparam.pem


### PR DESCRIPTION
Under some (docker) configs, when max fd's
are ste too high in the OS, squid may attempt
to xcalloc a huge amount of mem when starting.